### PR TITLE
[OFAC] Add first-ever Iran crypto exchange designations (Zedcex/Zedxion)

### DIFF
--- a/.automation/reports/report-2026-02-06.md
+++ b/.automation/reports/report-2026-02-06.md
@@ -1,0 +1,152 @@
+# Weekly Monitoring Report: 2026-01-30 to 2026-02-06
+
+## Significant Developments Found: 8
+
+---
+
+### 1. [SEC/CFTC] — Joint "Project Crypto" Harmonization Initiative Launched
+**Date:** January 29, 2026
+**Significance Level:** AUTO-INCLUDE
+**Source:** [SEC Press Release](https://www.sec.gov/newsroom/press-releases/2026-14-sec-cftc-reschedule-joint-event-harmonization-us-financial-leadership-crypto-era)
+**Summary:** SEC Chair Paul Atkins and CFTC Chair Michael Selig held a joint public event at CFTC headquarters and announced that "Project Crypto" — previously an SEC-led initiative — will proceed as a joint effort between both agencies to harmonize federal oversight of digital asset markets. This is the first time the two agencies have publicly committed to inter-agency alignment, jurisdictional cooperation, and forward-looking supervision rather than unilateral enforcement. Key focus areas include developing a clearer crypto asset taxonomy to delineate jurisdictional boundaries, reducing duplicative compliance requirements, and formalizing a comprehensive memorandum of understanding. Chair Selig also directed staff to withdraw the CFTC's 2024 proposed event contracts rule and a 2025 advisory notice on prediction markets.
+**Proposed Action:** Update `fedreg/sec.md` — new subsection under Guidance; Update `fedreg/cftc.md` — new subsection on Project Crypto and CFTC-SEC coordination
+**Key Citations:**
+- [SEC Opening Remarks — Chair Atkins](https://www.sec.gov/newsroom/speeches-statements/atkins-remarks-joint-sec-cftc-harmonization-event-project-crypto-012926)
+- [SEC-CFTC Harmonization Event Page](https://www.sec.gov/newsroom/meetings-events/sec-cftc-harmonization-us-financial-leadership-crypto-era)
+- [CFTC Press Release](https://www.cftc.gov/PressRoom/Events/opaeventcftcsec012926)
+- [Morrison Foerster Analysis](https://www.mofo.com/resources/insights/260130-sec-and-cftc-announce-joint-project-crypto-initiative)
+- [Baker McKenzie Analysis](https://blockchain.bakermckenzie.com/2026/02/05/sec-cftc-crypto-coordination-meeting-background-substance-and-implications/)
+- [Consumer Financial Services Law Monitor](https://www.consumerfinancialserviceslawmonitor.com/2026/02/cftc-and-sec-signal-new-era-of-crypto-harmonization-at-joint-project-crypto-event/)
+
+---
+
+### 2. [OFAC] — First-Ever Designation of Crypto Exchanges Under Iran Sanctions
+**Date:** January 30, 2026
+**Significance Level:** AUTO-INCLUDE
+**Source:** [Treasury Press Release](https://home.treasury.gov/news/press-releases/sb0225)
+**Summary:** OFAC designated two UK-registered cryptocurrency exchanges — Zedcex Exchange Ltd. and Zedxion Exchange Ltd. — for operating in Iran's financial sector and processing cryptocurrency transactions for the Islamic Revolutionary Guard Corps (IRGC). This marks the first time OFAC has specifically designated digital asset exchanges for operating in the financial sector of the Iranian economy. Zedcex reportedly processed over $94 billion in transactions since August 2022, with approximately $1 billion in IRGC-related transactions conducted primarily through Tether (USDT) on the Tron network. The exchanges are linked to Iranian businessman Babak Morteza Zanjani, previously sentenced to death for embezzling billions from Iran's National Oil Company. The designations were part of a broader action also targeting six Iranian officials for violent repression of protesters.
+**Proposed Action:** Update `fedreg/ofac.md` — Add under "Specific Entities / Markets" section
+**Key Citations:**
+- [Treasury Press Release](https://home.treasury.gov/news/press-releases/sb0225)
+- [Chainalysis Blog](https://www.chainalysis.com/blog/ofac-designates-iranian-crypto-exchanges-january-2026/)
+- [TRM Labs Analysis](https://www.trmlabs.com/resources/blog/ofac-sanctions-zedcex-and-zedxion-in-first-ever-designation-of-an-irgc-linked-digital-asset-exchange)
+- [CoinDesk Coverage](https://www.coindesk.com/policy/2026/01/31/u-s-imposes-sanctions-on-crypto-exchanges-tied-to-iran-for-first-time)
+
+---
+
+### 3. [Congress] — Senate Agriculture Committee Advances Crypto Market Structure Bill
+**Date:** January 29, 2026
+**Significance Level:** EVALUATE — Include (first Senate committee passage of crypto market structure bill)
+**Source:** [CNBC](https://www.cnbc.com/2026/01/29/senate-ag-committee-advances-crypto-bill-to-establish-cftc-regulatory-authority.html)
+**Summary:** The Senate Agriculture Committee voted to advance the Digital Commodity Intermediaries Act on a party-line vote (12 Republicans in favor, 11 Democrats opposed). This marks the first time a crypto market structure bill has advanced past a Senate committee. The bill would establish a clear legal definition of digital commodities and create a spot market digital commodity intermediary regulatory regime under the CFTC. The Senate Banking Committee must still approve its companion version before the two measures can combine and advance to the full Senate floor. The Banking Committee's consideration was postponed on January 15 amid industry pushback.
+**Proposed Action:** Flag for future update — significant legislative milestone, but still early in legislative process; does not yet warrant treatise update until further progress
+**Key Citations:**
+- [CoinDesk Live Blog](https://www.coindesk.com/policy/2026/01/29/live-crypto-bill-reaches-u-s-senate-milestone-as-lawmakers-mull-changes-on-way-to-vote)
+- [Senate Agriculture Committee Press Release](https://www.agriculture.senate.gov/newsroom/rep/press/release/boozman-leads-ag-committee-in-advancing-crypto-market-structure-legislation)
+- [Fortune Coverage](https://fortune.com/2026/01/29/clarity-act-gryfto-crypto-senate-agriculture-committee-booker-trump-banking/)
+
+---
+
+### 4. [SEC] — Dismissal of CryptoFed DAO Proceedings
+**Date:** February 2, 2026
+**Significance Level:** EVALUATE — Skip (continues established pattern of SEC dismissals; minor case)
+**Source:** [PR Newswire](https://www.prnewswire.com/news-releases/sec-dismisses-proceedings-against-american-cryptofed-dao-302679546.html)
+**Summary:** The SEC issued an Order Dismissing Proceedings against American CryptoFed DAO LLC, formally ending all proceedings against the first Wyoming DAO. The SEC acknowledged that "much has changed about the regulation of crypto assets since these events," citing the GENIUS Act, executive orders supporting blockchain growth, and SEC Chairman Atkins' support for clearer guidelines. CryptoFed is converting to a Wyoming DUNA (Decentralized Unincorporated Nonprofit Association). While notable, this continues the established pattern of SEC enforcement retreats under the Atkins administration and does not represent a novel development.
+**Proposed Action:** No immediate action — document in tracker but does not merit treatise update independently
+**Key Citations:**
+- [Lowenstein Sandler Crypto Brief - February 5, 2026](https://www.lowenstein.com/news-insights/newsletters/crypto-brief-february-5-2026)
+
+---
+
+### 5. [Treasury] — Secretary Bessent Pressures Crypto Industry on CLARITY Act
+**Date:** February 5, 2026
+**Significance Level:** EVALUATE — Include (significant policy signal from Treasury Secretary)
+**Source:** [CoinDesk](https://www.coindesk.com/policy/2026/02/05/u-s-treasury-s-bessent-calls-out-crypto-nihilists-resisting-market-structure-bill)
+**Summary:** U.S. Treasury Secretary Scott Bessent publicly called out crypto insiders obstructing the Digital Asset Market Clarity Act during testimony before the Senate Banking Committee. He stated, "There seems to be a nihilist group in the industry who prefers no regulation over this very good regulation," and added that crypto market participants who do not want the bill "should move to El Salvador." This is notable as the most forceful public statement from a sitting Treasury Secretary pressuring the crypto industry to support market structure legislation.
+**Proposed Action:** Flag for future update — significant policy signal but legislative outcome still uncertain
+**Key Citations:**
+- [Decrypt Coverage](https://decrypt.co/357082/treasury-secretary-crypto-nihilists-clarity-act-move-el-salvador)
+- [American Banker](https://www.americanbanker.com/news/bessent-pressures-crypto-nihilists-on-market-structure-bill)
+
+---
+
+### 6. [Congress] — Sen. Boozman Signals Continued Momentum on Crypto Legislation
+**Date:** February 5, 2026
+**Significance Level:** EVALUATE — Skip (process update, no substantive new development)
+**Source:** [CNBC](https://www.cnbc.com/2026/02/05/boozman-crypto-cftc-regulation.html)
+**Summary:** Senate Agriculture Committee Chairman John Boozman said in a February 5 interview that he feels "very strongly" about reaching agreement this year on a crypto market structure bill. He noted negotiations resumed immediately after his committee's vote and that work continues with Democratic colleagues. The Senate Banking Committee must still approve its version of the bill.
+**Proposed Action:** No action — process update for monitoring continuity
+**Key Citations:**
+- [CNBC Interview](https://www.cnbc.com/2026/02/05/boozman-crypto-cftc-regulation.html)
+
+---
+
+### 7. [DOJ] — Cartel Crypto Money Laundering Prosecutions
+**Date:** February 5-6, 2026
+**Significance Level:** EVALUATE — Flag (potentially significant given DOJ's official shift away from crypto enforcement)
+**Source:** [Washington Post](https://www.washingtonpost.com/business/2026/02/05/justice-department-cartels-money-laundering-cryptocurrency/a84f4a10-0290-11f1-ad9f-6f689ec6b060_story.html)
+**Summary:** The DOJ announced it is stepping up pressure on Mexican cartels' financial networks as money launderers increasingly route drug profits through cryptocurrency. Four defendants (Eduardo Rigoberto Velasco Calderon, Eliomar Segura Torres, Manuel Ignacio Correa, and Cesar Linares-Orozco) face money laundering conspiracy charges in Kentucky federal court. The cases illustrate that despite the disbanding of the National Cryptocurrency Enforcement Team (NCET) and the April 2025 "Ending Regulation by Prosecution" memo, the DOJ continues active crypto enforcement when tied to drug trafficking, cartel activity, and transnational criminal organizations.
+**Proposed Action:** No immediate action — worth monitoring as it demonstrates the carve-out in DOJ's new enforcement posture
+**Key Citations:**
+- [Fortune Coverage](https://fortune.com/2026/02/05/cartels-turn-to-crypto-in-game-of-finance-whack-a-mole-with-doj/)
+- [Military.com/AP Wire](https://www.military.com/daily-news/2026/02/05/justice-department-steps-pressure-cartels-financial-networks-launderers-turn-crypto.html)
+
+---
+
+### 8. [White House] — Crypto Adviser Leads Stakeholder Meeting on Market Structure Bill
+**Date:** February 2, 2026
+**Significance Level:** EVALUATE — Skip (process update)
+**Source:** [CoinDesk](https://www.coindesk.com/policy/2026/02/02/white-house-crypto-meeting-on-market-structure-bill)
+**Summary:** President Trump's crypto adviser Patrick Witt led a meeting with crypto and banking industry representatives to find a compromise on stablecoin yield provisions in the Digital Asset Market Clarity Act. Stakeholders were given new marching orders to reach compromise language on stablecoin yields before month's end.
+**Proposed Action:** No action — process update
+**Key Citations:**
+- [CoinDesk](https://www.coindesk.com/policy/2026/02/02/white-house-crypto-meeting-on-market-structure-bill)
+
+---
+
+## Recommended Pull Requests: 1
+
+### PR 1: Multi-Agency Updates — Project Crypto Initiative and OFAC Iran Exchange Designations
+**Files to Update:**
+- `fedreg/ofac.md` — Add Zedcex/Zedxion designation under "Specific Entities / Markets" section
+
+**Rationale for PR:**
+Two AUTO-INCLUDE developments occurred during this monitoring period:
+
+1. **OFAC Zedcex/Zedxion Designation** (Jan 30) — First-ever OFAC designation of crypto exchanges under Iran sanctions. This is a natural extension of the existing OFAC page's "Specific Entities / Markets" section, which already documents SUEX OTC, Hydra, and Garantex designations. The new designation represents a clear escalation in OFAC's approach and fits seamlessly into the existing content structure.
+
+2. **SEC-CFTC Project Crypto Initiative** (Jan 29) — While this is a significant new agency framework, the treatise's SEC and CFTC pages currently end circa 2022. Adding a single 2026 entry to pages that are missing 3+ years of developments (including the massive enforcement retreat, Gensler's departure, Atkins' confirmation, dismissal of Ripple/Coinbase/Binance cases, etc.) would create a jarring gap and potentially mislead readers about the current state of affairs. **Recommendation: Flag this for a larger comprehensive update to the SEC and CFTC pages rather than a piecemeal weekly addition.**
+
+**Therefore, the recommended PR scope is limited to the OFAC update only**, which fits naturally into the existing chronological narrative on that page.
+
+**Proposed Changes for OFAC page (`fedreg/ofac.md`):**
+
+Add the following after the existing Garantex bullet point in the "Specific Entities / Markets" section:
+
+```markdown
+* Designating two UK-registered cryptocurrency exchanges, Zedcex Exchange Ltd. and Zedxion Exchange Ltd., for operating in Iran's financial sector and processing cryptocurrency transactions for the Islamic Revolutionary Guard Corps (IRGC). This marked the first time OFAC designated digital asset exchanges specifically for operating in the financial sector of the Iranian economy. Zedcex had reportedly processed over $94 billion in transactions since its registration in August 2022, with approximately $1 billion in IRGC-related transactions conducted primarily through Tether (USDT) on the Tron network. The exchanges were linked to Iranian businessman Babak Morteza Zanjani, previously sentenced to death for embezzling billions from Iran's National Oil Company. OFAC, Press Release, [Treasury Sanctions Cryptocurrency Exchange and Network Enabling Sanctions Evasion and Cyber Criminals](https://home.treasury.gov/news/press-releases/sb0225) (2026.01.30)
+```
+
+---
+
+## Important Note: Treatise Content Gap
+
+The treatise content for `fedreg/sec.md` and `fedreg/cftc.md` currently ends circa 2022. Significant developments since then include:
+
+- **SEC:** Gensler's resignation, Atkins' confirmation, dismissal of enforcement actions against Coinbase/Ripple/Binance/Kraken, formation of the Crypto Task Force, withdrawal from "regulation by enforcement," and launch of Project Crypto
+- **CFTC:** New Chairman Michael Selig, "Crypto Sprint" initiative, withdrawal of actual delivery guidance, event contracts rulemaking withdrawal, and joint Project Crypto initiative
+- **Legislative:** GENIUS Act passage (July 2025), CLARITY Act introduction and committee activity, market structure bill progression
+- **Executive:** Multiple executive orders on crypto, establishment of White House crypto adviser role
+- **DOJ:** "Ending Regulation by Prosecution" memo (April 2025), disbanding of NCET
+
+A comprehensive update to these pages is strongly recommended as a separate project, as a weekly monitoring addition cannot adequately bridge a 3+ year content gap.
+
+---
+
+## Sources Checked With No Significant Findings
+
+- **FinCEN:** No new enforcement actions, rules, or guidance specific to the monitoring period. Ongoing GENIUS Act implementation work continues but no discrete events this week.
+- **Federal Reserve:** No CBDC or stablecoin developments this week. Federal Reserve CBDC activity effectively halted by the Anti-CBDC Surveillance State Act and Chair Powell's commitment not to pursue a digital dollar.
+- **IRS:** No new cryptocurrency guidance this week. Cost basis reporting under Form 1099-DA took effect January 1, 2026, but no new guidance issued during monitoring period.
+- **Federal Register:** Two procedural crypto-related filings noted (Nasdaq ISE crypto asset restrictions removal, NYSE American Grayscale ETF options timing extension) but neither rises to treatise-level significance.
+- **Courts:** No significant appellate decisions in major crypto cases during the monitoring period.

--- a/fedreg/ofac.md
+++ b/fedreg/ofac.md
@@ -28,7 +28,8 @@ OFAC began its focus on designating terrorist and criminal enterprises engaged i
 It then expanded from individual actors/addresses to entire cryptocurrency enterprises:
 
 * Designating SUEX OTC, a virtual currency exchange, that OFAC found had been involved in laundering eight different ransomware schemes, which resulted in over 40% of SUEX's known transaction history to be associated with illicit actors. OFAC, Press Release, [Treasury Takes Robust Actions to Counter Ransomware](https://home.treasury.gov/news/press-releases/jy0364) (2021.09.21)
-* Designating the darknet market Hydra and 100 associated virtual currency addresses, as well as virtual currency exchange Garantex, both operating out of Russia. OFAC, Press Release, [Treasury Sanctions Russia-Based Hydra, World’s Largest Darknet Market, and Ransomware-Enabling Virtual Currency Exchange Garantex](https://home.treasury.gov/news/press-releases/jy0701) (2022.04.05)
+* Designating the darknet market Hydra and 100 associated virtual currency addresses, as well as virtual currency exchange Garantex, both operating out of Russia. OFAC, Press Release, [Treasury Sanctions Russia-Based Hydra, World's Largest Darknet Market, and Ransomware-Enabling Virtual Currency Exchange Garantex](https://home.treasury.gov/news/press-releases/jy0701) (2022.04.05)
+* Designating two UK-registered cryptocurrency exchanges, Zedcex Exchange Ltd. and Zedxion Exchange Ltd., for operating in Iran's financial sector and processing cryptocurrency transactions for the Islamic Revolutionary Guard Corps (IRGC). This marked the first time OFAC designated digital asset exchanges specifically for operating in the financial sector of the Iranian economy. Zedcex had reportedly processed over $94 billion in transactions since its registration in August 2022, with approximately $1 billion in IRGC-related transactions conducted primarily through Tether (USDT) on the Tron network. The exchanges were linked to Iranian businessman Babak Morteza Zanjani, previously sentenced to death for embezzling billions from Iran's National Oil Company. OFAC, Press Release, [Treasury Sanctions Cryptocurrency Exchange and Network Enabling Sanctions Evasion and Cyber Criminals](https://home.treasury.gov/news/press-releases/sb0225) (2026.01.30)
 
 ### Virtual Currency Mixers <a href="#virtual-currency-mixers" id="virtual-currency-mixers"></a>
 
@@ -177,6 +178,7 @@ Other than these remarks, members of Treasury have made largely oblique referenc
 
 Sources are listed in reverse chronological order.
 
+* OFAC, Press Release, [Treasury Sanctions Cryptocurrency Exchange and Network Enabling Sanctions Evasion and Cyber Criminals](https://home.treasury.gov/news/press-releases/sb0225) (2026.01.30)
 * OFAC, Press Release, [Treasury Designates DPRK Weapons Representatives](https://home.treasury.gov/news/press-releases/jy1087) (2022.11.08)
 * OFAC, FAQ 1095, [Who is the Tornado Cash “person” that OFAC designated pursuant to E.O. 13722 (“Blocking Property of the Government of North Korea and the Workers’ Party of Korea, and Prohibiting Certain Transactions with Respect to North Korea”) and Executive Order (E.O.) 13694 (“Blocking the Property of Certain Persons Engaging in Significant Malicious Cyber-Enabled Activities”), as amended?](https://home.treasury.gov/policy-issues/financial-sanctions/faqs/1095) (2022.11.08)
 * OFAC, Press Release, [Treasury Sanctions IRGC-Affiliated Cyber Actors for Roles in Ransomware Activity](https://home.treasury.gov/news/press-releases/jy0948) (2022.09.14)


### PR DESCRIPTION
- Added Zedcex Exchange Ltd. and Zedxion Exchange Ltd. OFAC designation to "Specific Entities / Markets" section
- Updated Index of Sources with new citation in reverse chronological order
- Added weekly monitoring report for 2026-01-30 to 2026-02-06

Source: https://home.treasury.gov/news/press-releases/sb0225