### PR TITLE
[States] Add comprehensive Colorado cryptocurrency law section (2.06)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,4 +25,5 @@
   * [1.40 - Executive Actions](fedreg/exec.md)
 * [State Regulations](states/README.md)
   * [2.40 - Oklahoma](states/oklahoma.md)
+  * [2.44 - Texas](states/texas.md)
 * [Terms of Use](terms-of-use.md)

--- a/states/README.md
+++ b/states/README.md
@@ -7,3 +7,4 @@ Many states are considering and implementing crypto-related laws, often at varyi
 An overview of each U.S. state's law that addressing crypto in a specific way. This section is a work in progress and states are being added as time permits. Some section numbers may be omitted; these numbers are reserved for future additions.&#x20;
 
 * [2.40 - Oklahoma](oklahoma.md)
+* [2.44 - Texas](texas.md)

--- a/states/README.md
+++ b/states/README.md
@@ -6,5 +6,6 @@ Many states are considering and implementing crypto-related laws, often at varyi
 
 An overview of each U.S. state's law that addressing crypto in a specific way. This section is a work in progress and states are being added as time permits. Some section numbers may be omitted; these numbers are reserved for future additions.&#x20;
 
+* [2.06 - Colorado](colorado.md)
 * [2.40 - Oklahoma](oklahoma.md)
 * [2.44 - Texas](texas.md)

--- a/states/colorado.md
+++ b/states/colorado.md
@@ -1,0 +1,248 @@
+---
+description: An overview of crypto laws specific to Colorado.
+---
+
+# 2.06 - Colorado
+
+## Overview
+
+Colorado has been one of the more ambitious U.S. states in engaging with cryptocurrency and blockchain technology. Governor Jared Polis — a co-founder of the Congressional Blockchain Caucus during his time in the U.S. House — signed the Colorado Digital Token Act in 2019, making the state one of the first to create a state-level securities exemption for utility tokens. Colorado became the first state to accept cryptocurrency for tax payments in 2022. And the state hosts ETHDenver, the largest and longest-running Ethereum hackathon and conference in the world.
+
+The record is also one of pragmatic correction. The Digital Token Act was repealed in 2024 after five years without a single publicly documented filing — a clean illustration of the limits of state-level securities exemptions that do not address federal law. In its place, Colorado has pursued more targeted regulation: a 2023 adoption of UCC Article 12 for digital asset property rights, a 2025 modernization of the money transmission framework, and a 2025 statute regulating cryptocurrency ATM kiosks in response to a surge in consumer fraud.
+
+The state's enforcement posture has been consistently aggressive against fraud. The Division of Securities participated in Operation Cryptosweep in 2018, entering 18 cease-and-desist orders against ICOs. More recently, the INDXcoin case (2024-2025) resulted in a $3.34 million fraud judgment and 40 criminal counts against a Denver pastor who sold a worthless token to members of his congregation.
+
+## The Colorado Digital Token Act (2019-2024)
+
+### Origins
+
+The Digital Token Act emerged from the Colorado Council for the Advancement of Blockchain Technology Use, a 16-member body created by Governor John Hickenlooper in June 2018 and housed within the Colorado Office of Economic Development and International Trade (OEDIT). The Council — which included blockchain entrepreneurs, state regulators, and legal professionals — engaged more than 100 volunteers across working groups and produced a [final report &#x2197;](https://oedit.colorado.gov/sites/default/files/documents/blockchainreport_final_2-6-2019.pdf) in February 2019 identifying eight key problem areas, including securities regulatory clarity around token sales and money transmission rules for cryptocurrency.
+
+The Council's work followed a difficult 2018 legislative session in which several crypto-related bills narrowly failed. [HB 18-1426 &#x2197;](https://leg.colorado.gov/bills/hb18-1426), which would have exempted virtual currencies from the Money Transmitters Act, passed the House 57-8 but failed on Senate Third Reading 18-17. A companion bill, [SB 18-277 &#x2197;](https://leg.colorado.gov/bills/sb18-277), failed 15-20. A separate bill that would have required cryptocurrency dealers to obtain money transmitter licenses, [HB 18-1220 &#x2197;](https://leg.colorado.gov/bills/hb18-1220), passed the House but was indefinitely postponed in the Senate.
+
+### Enactment: SB 19-023
+
+[Senate Bill 19-023 &#x2197;](https://leg.colorado.gov/bills/sb19-023), the "Cryptocurrency Exemption Colorado Digital Token Act," was introduced on January 4, 2019. Prime sponsors were Sen. Stephen Fenberg (D) and Sen. Jack Tate (R) in the Senate, and Rep. Tracy Kraft-Tharp (D) and Rep. Hugh McKean (R) in the House, with 18 bipartisan co-sponsors. The bill passed unanimously in both chambers — 32-0 in the Senate and 62-0 in the House — and was signed by Governor Polis on March 8, 2019. It took effect August 2, 2019 and was codified at [Colo. Rev. Stat. Section 11-51-308.7 &#x2197;](https://law.justia.com/codes/colorado/title-11/securities/securities/article-51/part-3/section-11-51-308-7/).
+
+### Statutory Framework
+
+The Act created a securities registration exemption under the Colorado Securities Act for offers and sales of "digital tokens" meeting specific conditions. The exemption was not self-executing — it required the Securities Commissioner to promulgate implementing rules before any issuer could rely on it.
+
+**Definition of "digital token."** The Act defined a digital token as a digital unit meeting three cumulative criteria: (1) created in response to transaction verification on a digital ledger, by deploying code to a blockchain network, or a combination of both; (2) recorded in a digital ledger or database that is chronological, consensus-based, decentralized, and mathematically verified; and (3) capable of being traded or transferred between persons without an intermediary or custodian of value.
+
+**Exemption requirements.** An offer or sale of a digital token was exempt from securities registration only if all of the following conditions were met:
+
+* The issuer filed **Form DT-1** (notice of intent) with the Securities Commissioner before any offer or sale.
+* The **primary purpose** of the digital token was "consumptive" — defined as the ability to provide or receive goods, services, or content.
+* The issuer **marketed the token for consumptive use** and did **not** market it for speculative or investment purposes.
+* If the consumptive purpose was available at the time of sale, the exemption applied directly. If the consumptive purpose was **not yet available**, three additional conditions applied: (a) the consumptive purpose had to become available **within 180 days** of sale; (b) the initial buyer was **prohibited from reselling or transferring** the token until the consumptive purpose became available; and (c) the initial buyer had to provide a **knowing and clear acknowledgment** that the purchase was for consumptive, not investment, purposes.
+* The issuer complied with all Commissioner rules.
+
+A separate licensing exemption (Form DT-2) was available under [Rule 3.35 &#x2197;](https://www.law.cornell.edu/regulations/colorado/3-CCR-704-1-51-3.35) for persons effecting purchases, sales, or transfers of qualifying digital tokens.
+
+**Commissioner's rules.** The Securities Commissioner adopted three implementing regulations under [3 CCR 704-1 &#x2197;](https://www.law.cornell.edu/regulations/colorado/3-CCR-704-1-51-3.34), effective August 2, 2019:
+
+* **Rule 3.34** — Registration exemption: filing fees, Form DT-1 requirements, and Commissioner review procedures.
+* **Rule 3.35** — Licensing exemption: Form DT-2 requirements.
+* **Rule 3.36** — Books and records: five-year retention requirement for all digital token transactions; Commissioner examination authority without advance notice.
+
+Issuers were required to file amendments within 30 days of discovering material mistakes or changes in previously submitted filings.
+
+### Why the Act Failed
+
+Despite its ambitious design and unanimous legislative support, **no project is publicly known to have filed under the Colorado Digital Token Act.** The fundamental problem was structural: the Act provided only a state-level exemption from Colorado securities registration. It did nothing to address federal securities law. An issuer relying on the Colorado exemption still needed to comply with SEC registration requirements or qualify for a federal exemption such as Regulation D — which, as a practical matter, rendered the state exemption largely superfluous. Legal commentary at the time of enactment observed that the Act provided "primarily symbolic" relief and that "those in the crypto community seeking a full-bodied exemption from securities regulation will not find it." _See_ [ZwillGen, "Colorado Bill Seeks to Offer ICOs an Exemption" &#x2197;](https://www.zwillgen.com/general/colorado-bill-seeks-offer-icos-exemption-securities-regulations/); [Hunton Andrews Kurth, "Colorado Enacts Digital Token Act" &#x2197;](https://www.hunton.com/blockchain-legal-resource/colorado-enacts-digital-token-act).
+
+### Repeal: SB 24-180
+
+[Senate Bill 24-180 &#x2197;](https://leg.colorado.gov/bills/sb24-180) repealed the Digital Token Act effective August 7, 2024. Notably, Sen. Stephen Fenberg — an original prime sponsor of SB 19-023 in 2019 — co-sponsored the repeal. The bill passed 35-0 in the Senate and 59-2 in the House. The repeal reflected a legislative consensus that the Act had not achieved its objectives.
+
+### Comparison to Wyoming
+
+Wyoming's utility token exemption ([Wyo. Stat. Section 34-29-106 &#x2197;](https://law.justia.com/codes/wyoming/2022/title-34/chapter-29/section-34-29-106/)) took a broader approach: it exempted qualifying "open blockchain tokens" from both securities registration and money transmission laws, and classified them as intangible personal property. Wyoming's exemption remains in force. Colorado's approach was narrower (securities only) and more prescriptive (180-day window, transfer lock-up, buyer acknowledgment). Both share the same fundamental limitation — neither addresses federal securities law — but Wyoming's combined securities-and-money-transmission exemption provided marginally more practical value.
+
+## Securities Regulation and Enforcement
+
+The Colorado Division of Securities, within the Department of Regulatory Agencies (DORA), administers the Colorado Securities Act. The Securities Commissioner applies the _Howey_ investment-contract test to determine whether digital asset offerings constitute securities.
+
+### Operation Cryptosweep (2018)
+
+In May 2018, Securities Commissioner Gerald Rome convened an ICO Task Force to investigate potentially fraudulent cryptocurrency activity. By November 2018, Commissioner Rome had entered **18 cease-and-desist orders** against ICOs for unregistered securities offerings as part of NASAA's [Operation Cryptosweep &#x2197;](https://www.nasaa.org/45121/state-and-provincial-securities-regulators-conduct-coordinated-international-crypto-crackdown-2/) — a coordinated enforcement action involving more than 40 jurisdictions. Targets included BitConnect Ltd., Bitcoin Investments Ltd. (d/b/a DB Capital), PinkDate (an anonymously-operated escorting service ICO promising 50% profit dividends), Prisma (a lending platform claiming 27% returns), and multiple other offerings.
+
+### Nexo Settlement (2023)
+
+On March 17, 2023, the Division of Securities entered a [consent order against Nexo Capital Inc. &#x2197;](https://dora.colorado.gov/press-release/colorado-division-of-securities-joins-225-million-multistate-securities-settlement) as part of a $22.5 million multistate settlement. The allegation was that Nexo's Earn Interest Product — which promised investors interest on cryptocurrency deposits — constituted an unregistered security. Nexo agreed to stop offering the product in Colorado and cease paying interest on existing accounts by April 1, 2023. The SEC separately fined Nexo $22.5 million, bringing the combined penalty to $45 million.
+
+### INDXcoin / Regalado Fraud (2024-2025)
+
+The most significant recent Colorado crypto enforcement action involved INDXcoin, a token created by Denver pastor Eligio "Eli" Regalado Jr. and his wife Kaitlyn Regalado. From June 2022 to April 2023, the Regalados sold INDXcoin to more than 300 members of the Christian community through the "Kingdom Wealth Exchange," raising nearly $3.4 million. An auditor they hired gave the platform a security score of 0 out of 10 — which was never disclosed to investors. The exchange collapsed after a single day of trading.
+
+On January 16, 2024, Securities Commissioner Tung Chan [filed civil fraud charges &#x2197;](https://securities.colorado.gov/press-release/press-release-colorado-securities-commissioner-files-complaint-against-alleged). On April 15, 2025, Denver District Court granted summary judgment that INDXcoin met the definition of a security. After a three-day bench trial in May 2025, Judge Heidi L. Kutcher [entered judgment of $3,339,422.15 &#x2197;](https://securities.colorado.gov/press-release/press-release-denver-district-court-rules-indxcoin-cryptocurrency-scheme-was-a-fraud) against all defendants. Separately, a Denver grand jury criminally indicted the Regalados on 40 counts in July 2025.
+
+### Bitcoin ATM Scam Warnings (2024)
+
+On December 16, 2024, Commissioner Chan issued a [public warning &#x2197;](https://securities.colorado.gov/press-release/press-release-colorado-securities-commissioner-warns-of-massive-increase-in-scams) about a "massive increase in scams leveraging Bitcoin ATMs." The FTC had reported over $110 million in Bitcoin ATM scam losses nationally in 2023, a tenfold increase since 2020. This enforcement concern directly motivated the passage of SB 25-079, the Vending of Digital Assets Act.
+
+## Money Transmission
+
+### Statutory Framework
+
+Colorado's money transmission statute is codified at [C.R.S. Title 11, Article 110 &#x2197;](https://law.justia.com/codes/colorado/title-11/money-transmitters/article-110/). On April 18, 2025, Governor Polis signed [HB 25-1201 &#x2197;](https://leg.colorado.gov/bills/hb25-1201), the Money Transmission Modernization Act (MTMA), which repealed and reenacted Article 110 effective August 6, 2025. The MTMA is based on the Conference of State Bank Supervisors (CSBS) model law.
+
+### Application to Cryptocurrency
+
+The Colorado Division of Banking issued its first interim guidance on cryptocurrency and money transmission on September 20, 2018, establishing that:
+
+* Cryptocurrencies are not "money" or "legal tender" under Colorado law.
+* Pure **crypto-to-crypto exchanges** do not require a money transmitter license.
+* Licensing is required when an exchange (i) buys or sells cryptocurrency for fiat currency, (ii) allows customer-to-customer crypto transfers, and (iii) enables fiat transfer through the medium of cryptocurrency.
+
+On December 18, 2025, the Division issued [updated guidance &#x2197;](https://banking.colorado.gov/sites/banking/files/documents/Interim_Guidance_Cryptocurrency_and_the_MTMA_Final_12.18.25.pdf) under the revised MTMA, addressing the treatment of payment stablecoins as "stored value" and the federal preemption implications of the GENIUS Act.
+
+### Licensing Requirements
+
+License applications are filed through NMLS. The filing fee is $7,500 (January-June) or $3,750 (July-December). Surety bond minimums are $250,000, scaling to $1,000,000 or more for higher volumes. Under the MTMA, net worth requirements are the greater of $100,000 or a tiered percentage: 3% of the first $100 million in total assets, 2% of $100 million to $1 billion, and 0.5% above $1 billion. Background checks and fingerprinting are required.
+
+## Blockchain and Digital Assets
+
+### State Records: SB 18-086 (2018)
+
+[Senate Bill 18-086 &#x2197;](https://leg.colorado.gov/bills/sb18-086), signed by Governor Hickenlooper on May 30, 2018, required state agencies — including the Governor's Office of Information Technology, the Department of State, and DORA — to consider using distributed ledger technology and encryption techniques to protect confidential state records. The bill also encouraged higher education institutions to include blockchain in curricula; the University of Colorado at Colorado Springs received $1.8 million for blockchain-related scholarships and research.
+
+### UCC Article 12: SB 23-090 (2023)
+
+[Senate Bill 23-090 &#x2197;](https://leg.colorado.gov/bills/sb23-090), effective August 7, 2023, adopted the Uniform Law Commission's 2022 amendments to the Uniform Commercial Code, creating new Article 12 governing "controllable electronic records." The amendments address transfer of property rights in intangible digital assets (including virtual currencies and NFTs), security interests in controllable accounts and controllable payment intangibles, and updated definitions throughout Articles 1, 9, and 12. Colorado was among the first wave of approximately 24 states to adopt these amendments.
+
+### Electronic Transactions
+
+Colorado's adoption of the Uniform Electronic Transactions Act ([C.R.S. Section 24-71.3-107 &#x2197;](https://law.justia.com/codes/colorado/title-24/electronic-transactions/article-71-3/section-24-71-3-107/)) provides that records and signatures may not be denied legal effect or enforceability solely because they are in electronic form. While not blockchain-specific, this framework provides the legal basis under which blockchain-based records and signatures may be recognized as legally valid. Colorado has not enacted a dedicated blockchain records recognition or smart contract enforceability statute comparable to those in Arizona, Tennessee, or Wyoming.
+
+## Banking and Custody
+
+Colorado does not have a special-purpose depository institution charter for digital assets comparable to Wyoming's SPDI. However, existing trust company charters under [C.R.S. Title 11, Article 109 &#x2197;](https://law.justia.com/codes/colorado/title-11/trust-companies/article-109/) have been used for crypto custody. Etana Custody, Inc., a Colorado-chartered trust company, provided cryptocurrency custody services before the Division of Banking issued a cease-and-desist order on August 22, 2025, followed by a suspension order on September 19, 2025, and a liquidation and receivership order on November 7, 2025, due to financial reporting and capitalization failures.
+
+## Vending of Digital Assets Act (2025)
+
+[Senate Bill 25-079 &#x2197;](https://leg.colorado.gov/bills/sb25-079), signed by Governor Polis on June 2, 2025, created the Colorado Vending of Digital Assets Act, effective January 1, 2026. The statute regulates virtual currency kiosks (cryptocurrency ATMs) and requires:
+
+* Clear, conspicuous disclosures at the point of transaction warning about fraud risk.
+* Both printed and electronic receipts including transaction hashes, wallet addresses, and operator contact information.
+* Daily transaction limits: **$2,000 for new customers** (less than 7 days of transaction history) and **$10,500 for existing customers**.
+* A refund process for first-time customers defrauded in transactions involving wallets or exchanges outside the United States, provided the customer reports the fraud within 60 days.
+
+The bill was motivated by FTC data showing over $110 million in national Bitcoin ATM scam losses in 2023 — a tenfold increase since 2020 — and received public support from AARP Colorado.
+
+## State Leadership and Crypto Initiatives
+
+### Governor Polis
+
+Before becoming Governor, Jared Polis served as a U.S. Representative (CO-2, 2009-2019) and co-founded the Congressional Blockchain Caucus. He introduced the Cryptocurrency Tax Fairness Act of 2017 with Rep. David Schweikert (R-AZ), which would have exempted consumer cryptocurrency purchases under $600 from reporting requirements. As Governor, Polis signed the Digital Token Act (2019), delivered a keynote at ETHDenver in February 2022, and continued the blockchain program initiated by the Blockchain Council by appointing Thaddeus Batt as Colorado's first blockchain solution architect within OEDIT.
+
+### Cryptocurrency for State Payments
+
+In September 2022, Colorado became the **first U.S. state to accept cryptocurrency for state tax payments**, implemented through PayPal's cryptocurrency processing. The program covers individual and business income tax, sales and use tax, withholding tax, severance tax, and excise fuel tax. The state does not hold cryptocurrency — all payments are immediately converted to U.S. dollars, with a service fee of $1 plus 1.83%.
+
+Adoption has been minimal. Through December 2024: 8 payments totaling $16,426 in 2022 (September-December), 22 payments totaling $23,241 in 2023, and 48 payments totaling $17,544 in 2024 — approximately **$57,211 total**, representing roughly 0.0005% of the $11+ billion in income tax collected over that period. _See_ [Colorado Newsline, "Cryptocurrency Tax Revenue Negligible" &#x2197;](https://coloradonewsline.com/briefs/cryptocurrency-tax-revenue-colorado/).
+
+The Division of Motor Vehicles also began accepting cryptocurrency through PayPal for online transactions — including driver's license renewals and vehicle registration — in 2023. _See_ [Colorado DMV Cryptocurrency &#x2197;](https://dmv.colorado.gov/cryptocurrency).
+
+## Legislative Developments
+
+Colorado's crypto-related legislation spans four legislative sessions:
+
+**2018:**
+
+* **SB 18-086** — Blockchain for state records protection and higher education. Signed May 30, 2018.
+* **HB 18-1220** — Bitcoin dealer money transmitter licensing. Passed House; postponed indefinitely by Senate.
+* **HB 18-1426** — Virtual currency exemption from money transmitter licensing. Passed House 57-8; failed Senate Third Reading 18-17.
+* **SB 18-277** — Companion to HB 18-1426. Failed Senate Third Reading 15-20.
+
+**2019:**
+
+* **SB 19-023** — Colorado Digital Token Act. Signed March 8, 2019.
+* **HB 19-1247** — Study of agricultural applications for blockchain technology. Signed May 30, 2019.
+* **SB 19-184** — Blockchain for water rights management. Indefinitely postponed by Senate committee.
+
+**2023:**
+
+* **SB 23-090** — UCC Article 12 (controllable electronic records). Effective August 7, 2023.
+
+**2024:**
+
+* **SB 24-180** — Repeal of the Colorado Digital Token Act. Signed May 17, 2024.
+
+**2025:**
+
+* **HB 25-1201** — Money Transmission Modernization Act. Signed April 18, 2025.
+* **SB 25-079** — Vending of Digital Assets Act (Bitcoin ATM regulation). Signed June 2, 2025.
+
+## Industry Presence
+
+**ETHDenver** is the longest-standing and largest Ethereum hackathon and conference in the world, held annually in Denver. The 2024 event drew approximately 20,000 attendees; 2025 drew approximately 25,000. Governor Polis has delivered keynote addresses, and the event is a significant contributor to Colorado's crypto ecosystem. _See_ [ETHDenver &#x2197;](https://ethdenver.com/).
+
+Colorado-based crypto companies include the **Electric Coin Company** (developer of the Zcash privacy cryptocurrency, headquartered in Broomfield), **SALT Lending** (pioneer of crypto-backed lending since 2016), **Compass Mining** (headquartered in Denver, operating a 50,000-square-foot service center), and **Crusoe Energy** (Denver-based, specializing in using stranded natural gas to power mining operations). Solar-powered mining operations, including those by Aspen Creek Digital Corporation, have also been established in western Colorado.
+
+## Practical Considerations
+
+**Token offerings.** The Digital Token Act is no longer available. Any offer or sale of digital tokens to Colorado residents that constitutes a security must be registered under the Colorado Securities Act or qualify for an applicable exemption. Federal compliance (SEC registration or a Regulation D exemption) remains required regardless.
+
+**Money transmission.** Under the MTMA (effective August 2025), businesses exchanging cryptocurrency for fiat currency through a custodial platform generally need a Colorado money transmitter license. Pure crypto-to-crypto exchanges are generally exempt because cryptocurrency is not "money" under the statute. Stablecoin transactions receive particular scrutiny. Applications are filed through NMLS with a $7,500 fee and $250,000 minimum bond.
+
+**Securities enforcement.** The Division of Securities has demonstrated a consistent willingness to pursue emergency cease-and-desist orders against fraudulent crypto offerings, including out-of-state promoters marketing to Colorado investors. The INDXcoin case (2024-2025) confirms that the Commissioner will pursue both civil and criminal remedies.
+
+**Cryptocurrency ATMs.** Operators of virtual currency kiosks in Colorado must comply with the Vending of Digital Assets Act (effective January 1, 2026), including transaction limits, disclosure requirements, and fraud refund provisions.
+
+## Index of Sources
+
+**Statutes:**
+
+* [Colo. Rev. Stat. Section 11-51-308.7 — Colorado Digital Token Act (repealed) &#x2197;](https://law.justia.com/codes/colorado/title-11/securities/securities/article-51/part-3/section-11-51-308-7/)
+* [Colo. Rev. Stat. Title 11, Article 110 — Money Transmitters &#x2197;](https://law.justia.com/codes/colorado/title-11/money-transmitters/article-110/)
+* [Colo. Rev. Stat. Title 11, Article 109 — Trust Companies &#x2197;](https://law.justia.com/codes/colorado/title-11/trust-companies/article-109/)
+* [Colo. Rev. Stat. Section 24-71.3-107 — UETA &#x2197;](https://law.justia.com/codes/colorado/title-24/electronic-transactions/article-71-3/section-24-71-3-107/)
+* [Wyo. Stat. Section 34-29-106 — Open Blockchain Tokens &#x2197;](https://law.justia.com/codes/wyoming/2022/title-34/chapter-29/section-34-29-106/)
+
+**Implementing Regulations:**
+
+* [3 CCR 704-1-51-3.34 — Registration Exemption &#x2197;](https://www.law.cornell.edu/regulations/colorado/3-CCR-704-1-51-3.34)
+* [3 CCR 704-1-51-3.35 — Licensing Exemption &#x2197;](https://www.law.cornell.edu/regulations/colorado/3-CCR-704-1-51-3.35)
+* [3 CCR 704-1-51-3.36 — Books and Records &#x2197;](https://www.law.cornell.edu/regulations/colorado/3-CCR-704-1-51-3.36)
+
+**Legislative History:**
+
+* [SB 19-023 — Colorado Digital Token Act (2019) &#x2197;](https://leg.colorado.gov/bills/sb19-023)
+* [SB 24-180 — Repeal of Digital Token Act (2024) &#x2197;](https://leg.colorado.gov/bills/sb24-180)
+* [SB 23-090 — UCC Article 12 Amendments (2023) &#x2197;](https://leg.colorado.gov/bills/sb23-090)
+* [SB 18-086 — Blockchain for State Records (2018) &#x2197;](https://leg.colorado.gov/bills/sb18-086)
+* [HB 25-1201 — Money Transmission Modernization Act (2025) &#x2197;](https://leg.colorado.gov/bills/hb25-1201)
+* [SB 25-079 — Vending of Digital Assets Act (2025) &#x2197;](https://leg.colorado.gov/bills/sb25-079)
+* [HB 18-1426 — Virtual Currency Money Transmitter Exemption (2018, failed) &#x2197;](https://leg.colorado.gov/bills/hb18-1426)
+* [SB 18-277 — Virtual Currency Money Transmitter Exemption (2018, failed) &#x2197;](https://leg.colorado.gov/bills/sb18-277)
+* [HB 18-1220 — Bitcoin Dealer Licensing (2018, failed) &#x2197;](https://leg.colorado.gov/bills/hb18-1220)
+* [HB 19-1247 — Agricultural Blockchain Study (2019) &#x2197;](https://leg.colorado.gov/bills/hb19-1247)
+
+**Agency Guidance and Enforcement:**
+
+* [Colorado Division of Banking — Cryptocurrency and the MTMA Interim Guidance (Dec. 2025) &#x2197;](https://banking.colorado.gov/sites/banking/files/documents/Interim_Guidance_Cryptocurrency_and_the_MTMA_Final_12.18.25.pdf)
+* [DORA Division of Securities — INDXcoin Complaint (Jan. 2024) &#x2197;](https://securities.colorado.gov/press-release/press-release-colorado-securities-commissioner-files-complaint-against-alleged)
+* [DORA Division of Securities — INDXcoin Judgment (Sept. 2025) &#x2197;](https://securities.colorado.gov/press-release/press-release-denver-district-court-rules-indxcoin-cryptocurrency-scheme-was-a-fraud)
+* [DORA Division of Securities — Nexo Settlement (Mar. 2023) &#x2197;](https://dora.colorado.gov/press-release/colorado-division-of-securities-joins-225-million-multistate-securities-settlement)
+* [DORA Division of Securities — Bitcoin ATM Scam Warning (Dec. 2024) &#x2197;](https://securities.colorado.gov/press-release/press-release-colorado-securities-commissioner-warns-of-massive-increase-in-scams)
+* [NASAA — Operation Cryptosweep (2018) &#x2197;](https://www.nasaa.org/45121/state-and-provincial-securities-regulators-conduct-coordinated-international-crypto-crackdown-2/)
+
+**Reports and Analysis:**
+
+* [Colorado Blockchain Council Final Report (Feb. 2019) &#x2197;](https://oedit.colorado.gov/sites/default/files/documents/blockchainreport_final_2-6-2019.pdf)
+* [OEDIT — Blockchain Council &#x2197;](https://oedit.colorado.gov/about/blockchain-council)
+* [Colorado General Assembly — Blockchain Issue Brief &#x2197;](https://content.leg.colorado.gov/sites/default/files/r19-49_blockchain_issue_brief.pdf)
+
+**Industry and News:**
+
+* [ETHDenver &#x2197;](https://ethdenver.com/)
+* [Hunton Andrews Kurth, "Colorado Enacts Digital Token Act" (2019) &#x2197;](https://www.hunton.com/blockchain-legal-resource/colorado-enacts-digital-token-act)
+* [ZwillGen, "Colorado Bill Seeks to Offer ICOs an Exemption" (2019) &#x2197;](https://www.zwillgen.com/general/colorado-bill-seeks-offer-icos-exemption-securities-regulations/)
+* [Colorado Newsline, "Cryptocurrency Tax Revenue Negligible" &#x2197;](https://coloradonewsline.com/briefs/cryptocurrency-tax-revenue-colorado/)
+* [Colorado DMV — Cryptocurrency &#x2197;](https://dmv.colorado.gov/cryptocurrency)
+
+## Authors
+
+[@lawtoshi](https://twitter.com/lawtoshi)

--- a/states/texas.md
+++ b/states/texas.md
@@ -1,0 +1,222 @@
+---
+description: An overview of crypto laws specific to Texas.
+---
+
+# 2.44 - Texas
+
+## Overview
+
+Texas has emerged as one of the most significant U.S. jurisdictions for cryptocurrency and blockchain activity. The state's approach combines a business-friendly regulatory philosophy with meaningful consumer protection enforcement, creating an environment that has attracted major industry players — particularly in mining, where Texas hosts roughly 3,200 megawatts of capacity across dozens of facilities, representing an estimated 40% of U.S. Bitcoin hashrate.
+
+Three pillars define the Texas framework. First, the state integrated virtual currency into its Uniform Commercial Code in 2021, becoming only the second state (after Wyoming) to provide clear property rights and secured transaction rules for digital assets. Second, the 2023 Money Services Modernization Act drew a deliberate line between stablecoins (regulated as money transmission) and other virtual currencies (generally excluded), while a companion statute imposed proof-of-reserves and anti-commingling requirements on digital asset service providers in the wake of FTX's collapse. Third, Texas in 2025 became the first state to actually fund a strategic bitcoin reserve, purchasing approximately $5 million in bitcoin through an exchange-traded fund.
+
+At the same time, the Texas State Securities Board has been one of the most aggressive state-level enforcers in the digital asset space, entering more than 50 administrative orders against fraudulent or unregistered crypto offerings since 2017 — the first such state enforcement action in the country. Texas thus occupies a distinct position: welcoming to compliant operators, hostile to fraud, and increasingly sophisticated in its regulatory architecture.
+
+## Virtual Currency Statutory Framework
+
+### Business & Commerce Code Chapter 12
+
+House Bill 4474, enacted during the 87th Legislature and effective September 1, 2021, created [Chapter 12 of the Texas Business & Commerce Code &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.12.htm), titled "Virtual Currency." The bill was authored by Rep. Tan Parker with bipartisan co-authors and sponsored in the Senate by Sen. Bryan Hughes. _See_ [HB 4474 Bill Analysis &#x2197;](https://capitol.texas.gov/tlodocs/87R/analysis/html/HB04474E.htm).
+
+[Section 12.001 &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.12.htm#12.001) defines "virtual currency" as a digital representation of value that functions as a medium of exchange, unit of account, or store of value and is not legal tender. The definition excludes merchant rewards program value and digital representations used solely within online games.
+
+[Section 12.003 &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.12.htm#12.003) establishes property rights in virtual currency. A purchaser acquires all rights the transferor had or had power to transfer. Critically, a "qualifying purchaser" — one who obtains control for value and without notice of adverse claims — takes free of adverse claims, whether framed in conversion, replevin, constructive trust, equitable lien, or other theory. Filing a UCC financing statement under Chapter 9 does not constitute notice of an adverse claim.
+
+[Section 12.004 &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.12.htm#12.004) defines "control" of virtual currency. A person has control if the virtual currency or its system gives that person (A) the power to derive substantially all the benefit, (B) the exclusive power to prevent others from deriving substantially all the benefit, and (C) the exclusive power to transfer control — and the person can be readily identified as having those powers.
+
+### UCC Secured Transactions Amendments
+
+HB 4474 simultaneously amended [Chapter 9 (Secured Transactions) &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.9.htm) to integrate virtual currency into the state's commercial lending framework. Virtual currency was added to the UCC definitions at Section 9.102, and a new Section 9.1071 addresses control of virtual currency for secured transaction purposes. Security interests in virtual currency may be perfected either by filing a UCC financing statement or by obtaining control under Section 12.004. This framework enables virtual currency to serve as collateral in secured lending — a significant practical development for the industry.
+
+Texas has not yet adopted the Uniform Law Commission's 2022 UCC amendments (which include a national model "Article 12 — Controllable Electronic Records"), though the Texas Blockchain Council lists updating Chapter 12 to align with the national model as a policy priority.
+
+### Unclaimed Property
+
+Senate Bill 1244, enacted during the 89th Legislature and effective September 1, 2025, updated the Texas Property Code to include virtual currency within the state's unclaimed property framework. Holders with full control of private keys must report and deliver virtual currency in its native form, and the Comptroller is authorized to contract with custodians for safekeeping.
+
+## Money Transmission
+
+### The Money Services Modernization Act (Chapter 152)
+
+Senate Bill 895, enacted during the 88th Legislature and effective September 1, 2023, repealed the former Money Services Act ([Texas Finance Code Chapter 151 &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.151.htm)) and replaced it with the Money Services Modernization Act, codified at [Texas Finance Code Chapter 152 &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.152.htm). Any current analysis of Texas money transmission requirements must reference Chapter 152, not the repealed Chapter 151.
+
+The pivotal provision for cryptocurrency businesses is [Section 152.003(19) &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.152.htm#152.003), which defines "money or monetary value" to explicitly include qualifying stablecoins — those that are (A) pegged to a sovereign currency, (B) fully backed by assets held in reserve, and (C) grant the holder a right to redeem for sovereign currency. Other virtual currencies, including Bitcoin and Ether, are expressly excluded from the definition.
+
+The practical effect: exchanging cryptocurrency for sovereign currency through a third-party exchanger generally constitutes money transmission requiring a license. Direct peer-to-peer exchanges and pure crypto-to-crypto exchanges generally do not. Software and protocol developers that never take custody of funds are typically not engaged in money transmission.
+
+License applications are filed through NMLS with a $10,000 filing fee. Net worth requirements are tiered: $100,000 minimum (or 3% of total assets up to $100 million), scaling upward. Security requirements range from $100,000 to $500,000 depending on the tangible net worth ratio. Virtual currency applicants must submit a third-party security audit of their computer systems and may not count virtual currency holdings as permissible investments.
+
+### Supervisory Memorandum 1037
+
+The Texas Department of Banking has issued three versions of [Supervisory Memorandum 1037 &#x2197;](https://www.dob.texas.gov/public/uploads/files/consumer-information/sm1037.pdf), its primary guidance on virtual currency and money transmission:
+
+* **April 2014 (original):** Texas became the first state to issue formal guidance on cryptocurrency and money transmission, establishing that cryptocurrency is not "money" under the Money Services Act.
+* **January 2019 (amended):** Addressed stablecoins specifically, treating sovereign-backed stablecoins as "monetary value" while maintaining the exclusion for decentralized cryptocurrencies.
+* **January 2024 (revised):** Updated for the MSMA (Chapter 152), classifying qualifying stablecoins as "money or monetary value" and providing detailed analysis of when crypto-related activities constitute money transmission.
+
+### Digital Asset Service Providers (Chapter 160)
+
+Enacted in the wake of the FTX collapse, Senate Bill 770 (88th Legislature, 2023) created [Texas Finance Code Chapter 160 &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.160.htm), imposing requirements on digital asset service providers with 500 or more Texas customers or $10 million or more in customer funds. The statute prohibits commingling of customer funds, requires separate or omnibus custody accounts, mandates annual proof-of-reserves reports with auditor attestation, and provides for quarterly customer transparency into their holdings. Violations can result in license suspension or revocation.
+
+## Securities Regulation
+
+### Texas State Securities Board Enforcement
+
+The Texas State Securities Board has been among the most active state securities regulators in the cryptocurrency space. The TSSB applies the _Howey_ investment-contract test to determine whether digital asset offerings constitute securities under the Texas Securities Act. The Board's Director of Enforcement, Joseph Rotunda, filed an expert report at the State Office of Administrative Hearings articulating this framework, and the Board takes the position that tokens sold in ICOs are securities requiring registration of both the securities and the selling agents.
+
+On December 20, 2017, the TSSB entered an emergency cease-and-desist order against [USI-Tech &#x2197;](https://www.ssb.texas.gov/news-publications/usi-tech-limited), making Texas the first state securities regulator to enter an enforcement order against a cryptocurrency firm. Since then, the Commissioner has entered more than 50 administrative orders against crypto-related entities.
+
+Notable enforcement actions include:
+
+* **BitConnect (ENF-18-CDO-1754, 2018):** Emergency order against the $4.1 billion Ponzi scheme, whose token value collapsed following the Texas order and similar actions from other regulators.
+* **2018 ICO Sweep:** Sixteen enforcement actions in a single year, targeting fraudulent mining schemes (BTCRUSH, Mintage Mining), cloud mining fraud, and unregistered token offerings.
+* **BlockFi (2022):** Part of a $100 million multi-state settlement over unregistered interest-bearing crypto accounts.
+* **Nexo (ENF-23-CDO-1871, 2023):** $22.5 million settlement over unregistered crypto lending products.
+* **Sand Vegas Casino Club / Slotie NFT (2022):** Among the first state-level NFT enforcement actions in the country, targeting casino-themed NFT projects offering unregistered profit-sharing arrangements.
+* **Apertum/DAO1 (ENF-23-CDO-1879, 2023; dismissed 2025):** Initially challenged as an unregistered security, the TSSB dismissed the action in July 2025, confirming that neither the token nor the DAO1 DeFi platform constituted an investment contract — a notable early example of a state regulator formally clearing a DeFi project.
+
+The TSSB also publishes investor alerts on its [cryptocurrency scams resource page &#x2197;](https://www.ssb.texas.gov/cryptocurrency-scams), including warnings about BitConnect refund scams, pig butchering schemes, and impersonation fraud.
+
+## Cryptocurrency Mining
+
+### Texas as a Mining Hub
+
+Texas has become one of the world's largest cryptocurrency mining jurisdictions, driven by several structural advantages: a deregulated energy market administered by the Electric Reliability Council of Texas (ERCOT), some of the cheapest utility-scale solar in the country (approximately 2.8 cents per kilowatt-hour), abundant wind energy, no state income tax, and vocal political support from Governor Greg Abbott, Senator Ted Cruz, and the Texas Blockchain Council.
+
+The state hosts approximately 27 to 40 mining facilities consuming an estimated 3,200 megawatts total. Major operations include:
+
+* **Riot Platforms:** Rockdale facility (750 MW) and Corsicana facility (planned 1 GW, with 400 MW Phase 1 energized and 600 MW Phase 2 under evaluation for potential AI/HPC conversion). Riot's deployed hashrate reached 31.5 EH/s, and the company earned $71.2 million in ERCOT demand response credits in 2023 alone — including a single-month record of $31.7 million in August 2023.
+* **Marathon Digital:** Granbury facility (300 MW) and a 114 MW wind-powered behind-the-meter operation in Hansford County.
+* **Core Scientific:** Facilities in Denton (125 MW, expandable to 300 MW) and Pecos (71 MW, expandable to 234 MW), with the company headquartered in Austin and pivoting significant capacity toward a $6.1 billion AI data center campus.
+* **Bitdeer:** Rockdale facility (563 MW) with a 100 MW hydro-cooling conversion completed.
+
+### Grid Participation and Energy Policy
+
+Miners participate in ERCOT's grid management through several mechanisms. The Large Flexible Load program (requiring 75 MW or greater capacity) requires registration and allows ERCOT to monitor and manage large energy consumers. The Four Coincident Peak (4CP) program provides transmission cost reductions for loads that curtail during the four highest-demand intervals each summer. Miners also provide ancillary services and earn demand response credits by voluntarily shutting down during grid stress events.
+
+House Bill 591 (88th Legislature, 2023), signed by the Governor and passed 141-1, created a severance tax exemption for natural gas that would otherwise be flared but is instead diverted to on-site Bitcoin mining operations — directly incentivizing miners to reduce methane emissions.
+
+Senate Bill 1929 (88th Legislature, 2023) and subsequent SB 6 (89th Legislature, 2025) imposed registration requirements on large cryptocurrency loads. Facilities meeting the 75 MW threshold must register with ERCOT, report power demand data, and — under SB 6 — maintain remote disconnect capability and pay a $100,000 application fee. Penalties for noncompliance reach $25,000 per day.
+
+### Community Concerns
+
+Mining operations have generated significant community opposition in some areas. In Granbury (Hood County), residents near Marathon Digital's 300 MW facility reported health effects from sustained industrial noise, including migraines, hearing damage, and sleep disruption — prompting an [Earthjustice nuisance lawsuit &#x2197;](https://earthjustice.org/press/2024/granbury-residents-sue-local-bitcoin-mine-over-health-threatening-noise-pollution) filed in 2024. In Navarro County, the county commissioners' court denied Riot Platforms a reinvestment zone designation for its Corsicana expansion in March 2025. Local noise and zoning ordinances vary significantly — Texas counties generally have less zoning authority than incorporated cities, creating regulatory gaps that some communities have attempted to address through incorporation votes or county-level ordinances.
+
+## Banking and Custody
+
+On June 10, 2021, the Texas Department of Banking issued [Industry Notice 2021-03 &#x2197;](https://www.dob.texas.gov/public/uploads/files/news/Industrynotices/in2021-03.pdf), clarifying that authority for Texas state-chartered banks to provide virtual currency custody services already exists under [Texas Finance Code Section 32.001 &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.32.htm#32.001). Banks may custody virtual currency in a non-fiduciary capacity (acting as bailee, with the customer retaining legal title) or in a fiduciary capacity (requiring trust powers and potentially a charter amendment).
+
+The Department of Banking has also been active in enforcement. Following FTX's collapse in November 2022, the Department issued an emergency cease-and-desist order and entered a consent order against FTX US in December 2022 for unlicensed money transmission. The Department has entered at least 14 consent orders against crypto-related entities since 2020, including actions against BlockFi, Bittrex, Genesis Global Capital, Nexo, Blockchain.com, and Kraken. _See_ [Texas Department of Banking Enforcement Orders &#x2197;](https://www.dob.texas.gov/laws-regulations/enforcement-orders).
+
+In a notable corporate development, Coinbase Global, Inc. reincorporated from Delaware to Texas in November 2025, reflecting the state's growing attractiveness to major crypto businesses.
+
+## Blockchain and Smart Contracts
+
+Texas does not yet have a statute explicitly recognizing blockchain records or smart contracts by name. However, [Business & Commerce Code Chapter 322 &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.322.htm) — Texas's version of the Uniform Electronic Transactions Act — provides broad definitions of "electronic record," "electronic signature," and "automated transaction" that are generally understood to encompass blockchain-based records, signatures, and smart contract execution. Section 322.007 provides that a record or signature may not be denied legal effect or enforceability solely because it is in electronic form, and Section 322.014 recognizes that contracts may be formed by the interaction of electronic agents without human review.
+
+Two legislative efforts to provide explicit blockchain recognition have passed the Texas House but failed in the Senate:
+
+* **HB 3768 (88th Legislature, 2023):** Would have defined "digital asset," "distributed ledger technology," and "smart contract" in the Business Organizations Code; provided that blockchain can satisfy signature and writing requirements; established that blockchain-based records and smart contracts cannot be excluded as evidence solely due to their technological form; and created a new entity type for Decentralized Unincorporated Associations. The bill passed the House unanimously (140-0) on May 12, 2023, but died in the Senate Business & Commerce Committee.
+
+* **HB 4518 (89th Legislature, 2025):** A successor bill establishing Decentralized Unincorporated Nonprofit Associations (DUNAs) with governance through smart contracts and distributed ledger technology. Passed the House 118-14 on May 15, 2025, but was left pending in the Senate Business & Commerce Committee on May 23, 2025.
+
+Both bills indicate strong House support for explicit blockchain recognition, and practitioners should watch for renewed efforts in the 90th Legislature (2027).
+
+## Strategic Bitcoin Reserve
+
+Senate Bill 21, authored by Sen. Charles Schwertner and signed by Governor Abbott on June 20, 2025, established the [Texas Strategic Bitcoin Reserve &#x2197;](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=SB21) as a special fund outside the state treasury, administered by the Comptroller of Public Accounts.
+
+The reserve may hold bitcoin or any other cryptocurrency with an average market capitalization of at least $500 billion over the most recent 24-month period — a threshold currently met only by Bitcoin. Funding sources include legislative appropriations, investment proceeds, dedicated revenue streams, forks and airdrops from held assets, and voluntary cryptocurrency donations. A five-member advisory committee (the Comptroller, one investment advisory board member, and three crypto investment experts) oversees the fund, and biennial reports on holdings and valuation are required.
+
+The Legislature initially appropriated $10 million. Texas purchased approximately $5 million in bitcoin through an exchange-traded fund in November 2025, becoming the first state to actually fund a strategic cryptocurrency reserve. A companion bill, HB 4488, shields the reserve from periodic treasury fund sweeps.
+
+In January 2026, legislation was filed to expand the reserve's eligibility to include Ethereum and Solana by lowering the market capitalization threshold — though as of February 2026 that proposal remains pending.
+
+## Legislative Developments
+
+Texas's crypto-related legislation has accelerated significantly across the last three legislative sessions:
+
+**87th Legislature (2021):**
+
+* **HB 4474** — Created Business & Commerce Code Chapter 12 (Virtual Currency) and amended Chapter 9 (Secured Transactions). Signed by the Governor; effective September 1, 2021.
+* **HB 1576** — Established a 16-member Blockchain Work Group tasked with developing a master plan for expanding the blockchain industry in Texas. Signed by the Governor; effective September 1, 2021.
+
+**88th Legislature (2023):**
+
+* **SB 895** — Money Services Modernization Act, replacing Chapter 151 with Chapter 152 and explicitly addressing stablecoins. Effective September 1, 2023.
+* **SB 770** — Digital Asset Service Provider requirements (Chapter 160), including proof-of-reserves and anti-commingling. Effective September 1, 2023.
+* **HB 591** — Severance tax exemption for flared gas diverted to Bitcoin mining. Passed 141-1; effective September 1, 2023.
+* **SB 1929** — ERCOT registration requirements for large flexible loads including crypto miners. Effective September 1, 2023.
+* **SB 1751** — Would have capped miner participation in demand response programs and abolished mining tax abatements. Passed the Senate unanimously but died in the House State Affairs Committee.
+* **HB 3768** — Blockchain definitions, smart contract recognition, and decentralized entity framework. Passed the House 140-0; died in the Senate.
+
+**89th Legislature (2025):**
+
+* **SB 21** — Texas Strategic Bitcoin Reserve Act. Signed June 20, 2025; effective immediately.
+* **HB 4488** — Companion bill protecting the Bitcoin reserve from treasury fund sweeps. Effective immediately.
+* **SB 1244** — Unclaimed property provisions for virtual currency. Effective September 1, 2025.
+* **SB 6** — Grid emergency powers, remote disconnect requirements for large loads, $100,000 application fee. Signed; effective June 2025.
+* **HB 4518** — DUNAs (Decentralized Unincorporated Nonprofit Associations). Passed the House 118-14; died in the Senate.
+
+Key legislators driving Texas's crypto framework include Rep. Tan Parker (author of HB 4474 and HB 1576, now a state Senator), Sen. Charles Schwertner (SB 21), and Sen. Bryan Hughes (Senate sponsor of HB 4474).
+
+## Enforcement Actions
+
+Texas enforcement against crypto-related misconduct comes from three primary sources:
+
+**Texas State Securities Board:** More than 50 administrative orders since December 2017, when USI-Tech became the first crypto enforcement action by any state securities regulator. The TSSB's focus has been on fraudulent ICOs, unregistered token offerings, cloud mining fraud, Ponzi-style lending platforms (BitConnect, Celsius), unregistered interest-bearing accounts (BlockFi, Nexo), and — more recently — NFT-based securities (Sand Vegas Casino Club, Slotie NFT). The Board publishes all enforcement orders and maintains active investor education resources. _See_ [TSSB Enforcement Actions &#x2197;](https://www.ssb.texas.gov/texas-securities-act-background/enforcement-actions).
+
+**Texas Department of Banking:** At least 14 consent orders against crypto entities since 2020, primarily for operating without required money transmission licenses. The FTX US emergency order (November 2022) and consent order (December 2022) were among the swiftest state-level responses to the FTX collapse.
+
+**Attorney General:** The Texas Attorney General led an 18-state coalition lawsuit against the SEC in November 2024, challenging federal authority to regulate digital assets — positioning Texas as opposing federal crypto overreach. The Legislature also enacted SB 1498 (89th Legislature, 2025), expanding digital asset forfeiture authority.
+
+## Practical Considerations
+
+**Money transmission licensing.** Businesses exchanging cryptocurrency for fiat currency through a custodial platform generally need a Texas money transmission license under Chapter 152. Pure crypto-to-crypto exchanges and non-custodial software providers are generally exempt. Stablecoin transactions receive particular scrutiny. Applications go through NMLS; expect a $10,000 filing fee, net worth requirements starting at $100,000, and a mandatory third-party security audit.
+
+**Securities compliance.** Token offerings to Texas residents are likely securities requiring registration or an exemption. The TSSB has shown no hesitation in pursuing emergency cease-and-desist orders, and its enforcement reach extends to out-of-state promoters marketing to Texas investors. The Apertum/DAO1 dismissal (2025) suggests some DeFi protocols may fall outside the investment-contract framework, but practitioners should not rely on that outcome as a blanket safe harbor.
+
+**Mining operations.** Facilities at or above 75 MW must register with ERCOT and comply with SB 6's remote disconnect and reporting requirements ($100,000 application fee; $25,000/day noncompliance penalty). Local permitting varies significantly — operators should confirm county and municipal noise ordinances, zoning requirements, and tax abatement eligibility before committing to a site. Community relations have become a material risk factor, particularly in rural counties with limited regulatory infrastructure.
+
+**Banking and custody.** Texas state-chartered banks have clear authority to custody virtual currency under Industry Notice 2021-03. Trust company charters provide an alternative path. Digital asset service providers meeting the Chapter 160 thresholds (500+ Texas customers or $10M+ in customer assets) must comply with proof-of-reserves, anti-commingling, and transparency requirements.
+
+## Index of Sources
+
+**Statutes:**
+
+* [Tex. Bus. & Com. Code Chapter 12 — Virtual Currency &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.12.htm)
+* [Tex. Bus. & Com. Code Chapter 9 — Secured Transactions &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.9.htm)
+* [Tex. Bus. & Com. Code Chapter 322 — UETA &#x2197;](https://statutes.capitol.texas.gov/Docs/BC/htm/BC.322.htm)
+* [Tex. Fin. Code Chapter 152 — Money Services Modernization Act &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.152.htm)
+* [Tex. Fin. Code Chapter 160 — Digital Asset Service Providers &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.160.htm)
+* [Tex. Fin. Code § 32.001 &#x2197;](https://statutes.capitol.texas.gov/Docs/FI/htm/FI.32.htm#32.001)
+
+**Agency Guidance:**
+
+* [Texas Department of Banking, Supervisory Memorandum 1037 &#x2197;](https://www.dob.texas.gov/public/uploads/files/consumer-information/sm1037.pdf)
+* [Texas Department of Banking, Industry Notice 2021-03 (Virtual Currency Custody) &#x2197;](https://www.dob.texas.gov/public/uploads/files/news/Industrynotices/in2021-03.pdf)
+* [Texas Department of Banking, Enforcement Orders &#x2197;](https://www.dob.texas.gov/laws-regulations/enforcement-orders)
+* [Texas State Securities Board, Enforcement Actions &#x2197;](https://www.ssb.texas.gov/texas-securities-act-background/enforcement-actions)
+* [Texas State Securities Board, Cryptocurrency Scams &#x2197;](https://www.ssb.texas.gov/cryptocurrency-scams)
+
+**Legislative History:**
+
+* [HB 4474 (87th Legislature, 2021) — Bill Analysis &#x2197;](https://capitol.texas.gov/tlodocs/87R/analysis/html/HB04474E.htm)
+* [SB 21 (89th Legislature, 2025) — Bill History &#x2197;](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=SB21)
+* [HB 3768 (88th Legislature, 2023) — Bill Text &#x2197;](https://capitol.texas.gov/tlodocs/88R/billtext/html/HB03768I.htm)
+* [Texas Blockchain Council — Policy Page &#x2197;](https://texasblockchaincouncil.org/policy-page)
+
+**Enforcement:**
+
+* [TSSB — USI-Tech Emergency Order (2017.12.20) &#x2197;](https://www.ssb.texas.gov/news-publications/usi-tech-limited)
+* [Earthjustice — Granbury Bitcoin Mine Noise Lawsuit (2024) &#x2197;](https://earthjustice.org/press/2024/granbury-residents-sue-local-bitcoin-mine-over-health-threatening-noise-pollution)
+* [Texas Department of Banking — Virtual Currency Guidance &#x2197;](https://www.dob.texas.gov/consumer-information/virtual-currency-guidance)
+
+**Industry and News:**
+
+* [Texas Blockchain Council Spearheads Passage of Two Blockchain Laws (2021) &#x2197;](https://www.prnewswire.com/news-releases/texas-blockchain-council-spearheads-passage-of-two-blockchain-laws-301333162.html)
+* [Hunton Andrews Kurth — Texas Establishes Strategic Bitcoin Reserve (2025) &#x2197;](https://www.hunton.com/blockchain-legal-resource/texas-establishes-strategic-bitcoin-reserve)
+
+## Authors
+
+[@lawtoshi](https://twitter.com/lawtoshi)


### PR DESCRIPTION
## Summary
- Adds new section 2.06 covering Colorado's cryptocurrency regulatory landscape
- Centers on the Colorado Digital Token Act (SB 19-023, 2019) — its enactment, detailed statutory framework, failure to attract any known filings, and unanimous repeal in 2024 (SB 24-180)
- Covers securities enforcement (Operation Cryptosweep 2018, Nexo $22.5M settlement, INDXcoin $3.34M fraud judgment), money transmission modernization (HB 25-1201, MTMA), UCC Article 12 adoption (SB 23-090), Vending of Digital Assets Act (SB 25-079, Bitcoin ATM regulation), and Governor Polis's crypto initiatives (first state to accept crypto for taxes)
- Updates states/README.md index to include Colorado

## Test plan
- [ ] Review all statutory citations link to leg.colorado.gov, justia.com, law.cornell.edu, or official state agency sites (no CaseText links)
- [ ] Verify Digital Token Act details against SB 19-023 enrolled text
- [ ] Confirm repeal date and SB 24-180 details
- [ ] Check formatting consistency with Texas (2.44) section style
- [ ] Verify Index of Sources is reverse-chronological within categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)